### PR TITLE
Updated documentation and charts for OCP 3.11 support

### DIFF
--- a/SpringContainerMS/Jenkinsfile.NoKubernetesPlugin
+++ b/SpringContainerMS/Jenkinsfile.NoKubernetesPlugin
@@ -1,0 +1,61 @@
+pipeline {
+
+    agent {
+        label "docker"
+    }
+
+    parameters {
+        string(name: 'REGISTRY', defaultValue: 'docker.io', description: 'Container Registry URL')
+        string(name: 'REGISTRY_NAMESPACE', defaultValue: 'ibmcase', description: 'registry namespace to push image to')
+        string(name: 'IMAGE_NAME', defaultValue: 'kc-spring-container-ms', description: 'name of image')
+        string(name: 'DOCKERFILE', defaultValue: 'Dockerfile', description: 'name of Dockerfile for build to use')
+        string(name: 'CONTEXT_DIR', defaultValue: 'SpringContainerMS', description: 'directory to work from inside source code')
+        credentials(name: 'REGISTRY_CREDENTIALS', defaultValue: 'registry-credentials-id', description: 'Credentials for registry', credentialType: 'Username with password')
+    }
+
+    stages {
+        stage('Build Docker Image') {
+            steps {
+              sh """
+              #!/bin/bash
+              cd ${env.CONTEXT_DIR}
+
+              if [ "${env.REGISTRY}" = "docker.io" ]; then
+                echo 'Building Docker Hub Image'
+                docker build -t ${env.IMAGE_NAME}:${env.BUILD_NUMBER} -f ${env.DOCKERFILE} .
+              else
+                echo 'Building Private Registry Image'
+                docker build -t ${env.REGISTRY}/${env.REGISTRY_NAMESPACE}/${env.IMAGE_NAME}:${env.BUILD_NUMBER} -f ${env.DOCKERFILE} .
+              fi
+            """
+            }
+        }
+
+        stage('Push Docker Image to Registry') {
+          steps {
+            withCredentials([usernamePassword(credentialsId: env.REGISTRY_CREDENTIALS,
+                                            usernameVariable: 'USERNAME',
+                                            passwordVariable: 'PASSWORD')]) {
+                sh """
+                #!/bin/bash\
+
+                docker login -u ${USERNAME} -p ${PASSWORD} ${env.REGISTRY}
+
+                if [ "${env.REGISTRY}" = "docker.io" ]; then
+                    echo 'Pushing to Docker Hub'
+                    docker push ${env.IMAGE_NAME}:${env.BUILD_NUMBER}
+                    docker tag ${env.IMAGE_NAME}:${env.BUILD_NUMBER} ${env.IMAGE_NAME}:latest
+                    docker push ${env.IMAGE_NAME}:latest
+                else
+                    echo 'Pushing to Private Registry'
+                    docker push ${env.REGISTRY}/${env.REGISTRY_NAMESPACE}/${env.IMAGE_NAME}:${env.BUILD_NUMBER}
+                    docker tag ${env.REGISTRY}/${env.REGISTRY_NAMESPACE}/${env.IMAGE_NAME}:${env.BUILD_NUMBER} ${env.REGISTRY}/${env.REGISTRY_NAMESPACE}/${env.IMAGE_NAME}:latest
+                    docker push ${env.REGISTRY}/${env.REGISTRY_NAMESPACE}/${env.IMAGE_NAME}:latest
+                fi
+                """
+            }
+          }
+        }
+
+    }
+}

--- a/SpringContainerMS/chart/springcontainerms/templates/deployment.yaml
+++ b/SpringContainerMS/chart/springcontainerms/templates/deployment.yaml
@@ -40,7 +40,10 @@ spec:
           - name: KAFKA_ENV
             value: "{{ .Values.eventstreams.env }}"
           - name: KAFKA_BROKERS
-            value: "{{ .Values.eventstreams.brokers }}"
+            valueFrom:
+              configMapKeyRef:
+                name: "{{ .Values.eventstreams.brokersConfigMap }}"
+                key: brokers
           {{if or (eq .Values.eventstreams.env "IBMCLOUD") (eq .Values.eventstreams.env "ICP")}}
           - name: KAFKA_APIKEY
             valueFrom:

--- a/SpringContainerMS/chart/springcontainerms/values.yaml
+++ b/SpringContainerMS/chart/springcontainerms/values.yaml
@@ -34,8 +34,12 @@ istio:
   enabled: false
   weight: 100
 eventstreams:
-  brokers: kafka03-prod02.messagehub.services.us-south.bluemix.net:9093,kafka01-prod02.messagehub.services.us-south.bluemix.net:9093,kafka02-prod02.messagehub.services.us-south.bluemix.net:9093,kafka04-prod02.messagehub.services.us-south.bluemix.net:9093,kafka05-prod02.messagehub.services.us-south.bluemix.net:9093
+  brokersConfigMap: kafka-brokers
+  #brokers:
+  #  - kafka01-prod02.messagehub.services.us-south.bluemix.net:9093
+  #  - kafka02-prod02.messagehub.services.us-south.bluemix.net:9093
   env: IBMCLOUD
 java:
   truststore:
     pwd: changeit
+serviceAccountName: default

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -15,7 +15,7 @@ See how to use docker-compose to run backend service and the solution in [this a
 
 ### Prepare an IBM Kubernetes service cluster
 
-See [this note on how to deploy a IKS cluster](https://ibm-cloud-architecture.github.io/refarch-kc/deployments/iks/#kubernetes-cluster-service). 
+See [this note on how to deploy a IKS cluster](https://ibm-cloud-architecture.github.io/refarch-kc/deployments/iks/#kubernetes-cluster-service).
 
 Define a docker image private registry using [this note.](https://ibm-cloud-architecture.github.io/refarch-kc/deployments/iks/#define-an-image-private-repository)
 
@@ -39,8 +39,46 @@ Follow [product documentation.](https://cloud.ibm.com/catalog/services/databases
 
 Then add secrets for postgresql by following the procedure described [in this note.](https://ibm-cloud-architecture.github.io/refarch-kc/deployments/iks/#postgresql-url-user-pwd-and-ca-certificate-as-secrets)
 
-## Private Cloud 
+## Private Cloud
 
 For [ IBM Cloud Private deployments go to this article.](https://ibm-cloud-architecture.github.io/refarch-kc/deployments/icp/)
 
+## Deploy to OpenShift Container Platform (OCP)
 
+### Deploy to OCP 3.11
+
+**Cross-component deployment prerequisites:** _(needs to be done once per unique deployment of the entire application)_
+1. If desired, create a non-default Service Account for usage of deploying and running the K Container reference implementation.  This will become more important in future iterations, so it's best to start small:
+  - Command: `oc create serviceaccount -n <target-namespace> kcontainer-runtime`
+  - Example: `oc create serviceaccount -n eda-refarch kcontainer-runtime`
+2. The target Service Account needs to be allowed to run containers as `anyuid` for the time being:
+  - Command: `oc adm policy add-scc-to-user anyuid -z <service-account-name> -n <target-namespace>`
+  - Example: `oc adm policy add-scc-to-user anyuid -z kcontainer-runtime -n eda-refarch`
+  - NOTE: This requires `cluster-admin` level privileges.
+
+**Perform the following for the `SpringContainerMS` microservice:**
+1. Build and push Docker image
+  1. Create a Jenkins project, pointing to the remote GitHub repository for the Order Microservices, creating the necessary parameters:
+    - Create a String parameter named `REGISTRY` to determine a remote registry that is accessible from your cluster.
+    - Create a String parameter named `REGISTRY_NAMESPACE` to describe the registry namespace to push image into.
+    - Create a String parameter named `IMAGE_NAME` which should be self-expalantory.  Default values should be correct.
+    - Create a String parameter named `CONTEXT_DIR` to determine the correct working directory to work from inside the source code, with respect to the root of the repository.  Default values should be correct.
+    - Create a String parameter named `DOCKERFILE` to determine the desired Dockerfile to use to build the Docker image.  This is determined with respect to the `CONTEXT_DIR` parameter.  Default values should be correct.
+    - Create a Credentials parameter named `REGISTRY_CREDENTIALS` and assign the necessary credentials to allow Jenkins to push the image to the remote repository.
+  2. Manually build the Docker image and push it to a registry that is accessible from your cluster (Docker Hub, IBM Cloud Container Registry, manually deployed Quay instance):
+    - `docker build -t <private-registry>/<image-namespace>/kc-spring-container-ms:latest order-command-ms/`
+    - `docker login <private-registry>`
+    - `docker push <private-registry>/<image-namespace>/kc-spring-container-ms:latest`
+3. Generate application YAMLs via `helm template`:
+  - Parameters:
+    - `--set image.repository=<private-registry>/<image-namespace>/<image-repository>`
+    - `--set image.tag=latest`
+    - `--set image.pullSecret=<private-registry-pullsecret>` (optional or set to blank)
+    - `--set image.pullPolicy=Always`
+    - `--set eventstreams.env=ICP`
+    - `--set serviceAccountName=<service-account-name>`
+    - `--namespace <target-namespace>`
+    - `--output-dir <local-template-directory>`
+  - Example: `helm template --set image.repository=rhos-quay.internal-network.local/browncompute/kc-spring-container-ms --set image.tag=latest --set image.pullSecret= --set image.pullPolicy=Always --set eventstreams.env=ICP --set serviceAccountName=kcontainer-runtime --output-dir templ --namespace eda-refarch chart/springcontainerms/`
+4. Deploy application using `oc apply`:
+  - `oc apply -f templates/springcontainerms/templates`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,16 @@
 # Environment pre-requisites
 
+## Deployment prerequisites
+
+Regardless of specific deployment targets (OCP, IKS, k8s), the following prerequisite Kubernetes artifacts need to be created to support the deployments of application components.  These artifacts need to be created once per unique deployment of the entire application and can be shared between application components in the same overall application deployment.
+
+1. Create `kafka-brokers` ConfigMap
+  - Command: `kubectl create configmap kafka-brokers --from-literal=brokers='<replace with comma-separated list of brokers>' -n <namespace>`
+  - Example: `kubectl create configmap kafka-brokers --from-literal=brokers='broker-3-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-2-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-1-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-5-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-0-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093,broker-4-j7fxtxtp5fs84205.kafka.svc01.us-south.eventstreams.cloud.ibm.com:9093' -n eda-refarch`
+2. Create optional `eventstreams-apikey` Secret, if you are using Event Streams as your Kafka broker provider
+  - Command: `kubectl create secret generic eventstreams-apikey --from-literal=binding='<replace with api key>' -n <namespace>`
+  - Example: `kubectl create secret generic eventstreams-apikey --from-literal=binding='z...12345...notanactualkey...67890...a' -n eda-refarch`
+
 ## Local deployment
 
 ### Prepare minikube or docker edge / kubernetes
@@ -58,12 +69,12 @@ For [ IBM Cloud Private deployments go to this article.](https://ibm-cloud-archi
 
 **Perform the following for the `SpringContainerMS` microservice:**
 1. Build and push Docker image
-  1. Create a Jenkins project, pointing to the remote GitHub repository for the Order Microservices, creating the necessary parameters:
+  1. Create a Jenkins project, pointing to the remote GitHub repository for the Order Microservices, creating the necessary parameters.  Refer to the individual microservice's `Jenkinsfile.NoKubernetesPlugin` for appropriate parameter values.
     - Create a String parameter named `REGISTRY` to determine a remote registry that is accessible from your cluster.
     - Create a String parameter named `REGISTRY_NAMESPACE` to describe the registry namespace to push image into.
-    - Create a String parameter named `IMAGE_NAME` which should be self-expalantory.  Default values should be correct.
-    - Create a String parameter named `CONTEXT_DIR` to determine the correct working directory to work from inside the source code, with respect to the root of the repository.  Default values should be correct.
-    - Create a String parameter named `DOCKERFILE` to determine the desired Dockerfile to use to build the Docker image.  This is determined with respect to the `CONTEXT_DIR` parameter.  Default values should be correct.
+    - Create a String parameter named `IMAGE_NAME` which should be self-expalantory.
+    - Create a String parameter named `CONTEXT_DIR` to determine the correct working directory to work from inside the source code, with respect to the root of the repository.
+    - Create a String parameter named `DOCKERFILE` to determine the desired Dockerfile to use to build the Docker image.  This is determined with respect to the `CONTEXT_DIR` parameter.
     - Create a Credentials parameter named `REGISTRY_CREDENTIALS` and assign the necessary credentials to allow Jenkins to push the image to the remote repository.
   2. Manually build the Docker image and push it to a registry that is accessible from your cluster (Docker Hub, IBM Cloud Container Registry, manually deployed Quay instance):
     - `docker build -t <private-registry>/<image-namespace>/kc-spring-container-ms:latest order-command-ms/`


### PR DESCRIPTION
Updated documentation for deployment to OCP 3.11, as well as moved `kafka-broker` definition into a ConfigMap and updated Chart files to accommodate.