### PR TITLE
set container to loaded when no capacity left

### DIFF
--- a/SpringContainerMS/src/main/java/ibm/labs/kc/containermgr/ContainerService.java
+++ b/SpringContainerMS/src/main/java/ibm/labs/kc/containermgr/ContainerService.java
@@ -65,7 +65,7 @@ public class ContainerService {
 		
 	public int manageCapacity(int quantityToFill,ContainerEntity ce) {
 		int currentCapa = ce.getCapacity();
-		if ( ce.getCapacity() >= quantityToFill) {  
+		if ( ce.getCapacity() > quantityToFill) {  
 			  ce.setCapacity(currentCapa-quantityToFill);
 			  ce.setStatus(ContainerStatus.PartiallyLoaded);
 			  return 0;		 


### PR DESCRIPTION
Setting the container to loaded when its capacity is equal to the quantity to fill. Otherwise, the container would remain as partially loaded with capacity 0. This would  even have worse implications than just a bad status as next order will get this container as an allocated container when it is not carrying any quantity at all from this new order.