### PR TITLE
Correct name of secret for KAFKA_APIKEY

### DIFF
--- a/app-deploy.yaml
+++ b/app-deploy.yaml
@@ -49,7 +49,7 @@ spec:
     valueFrom:
       secretKeyRef:
         key: binding
-        name: kafka-apikey
+        name: eventstreams-apikey
         optional: true
   - name: KCSOLUTION_CONTAINERS_TOPIC
     valueFrom:


### PR DESCRIPTION
Corrects the secret name for KAFKA_APIKEY to match the other deployments and existing helm charts.

I was considering changing the name of this secret in the conversion to Appsody, but decided that should be done separately (if at all).  But it seems I forgot to revert the name in the app-deploy.yaml that was part of PR #46.