### PR TITLE
Merge PostgreSQL creds into single secret

### DIFF
--- a/app-deploy.yaml
+++ b/app-deploy.yaml
@@ -72,18 +72,18 @@ spec:
   - name: POSTGRESQL_URL
     valueFrom:
       secretKeyRef:
-        key: binding
-        name: postgresql-url
+        key: url
+        name: postgresql-creds
   - name: POSTGRESQL_USER
     valueFrom:
       secretKeyRef:
-        key: binding
-        name: postgresql-user
+        key: username
+        name: postgresql-creds
   - name: POSTGRESQL_PWD
     valueFrom:
       secretKeyRef:
-        key: binding
-        name: postgresql-pwd
+        key: password
+        name: postgresql-creds
   - name: ANOMALY_THRESHOLD
     valueFrom:
       configMapKeyRef:


### PR DESCRIPTION
Signed-off-by: Rick Osowski <rosowski@gmail.com>

This will be a multi-phase commit process:

1. Adding in the postgres-creds Secrets to all the environments **PRs:** [#1](https://github.com/ibm-cloud-architecture/refarch-kc-gitops/pull/26) / [#2](https://github.com/ibm-cloud-architecture/refarch-kc-gitops/pull/27)
2. Updating the refarch-kc-container-ms app-deploy.yaml file to use the new Secret names/keys _(This PR)_
3. Remove the old postgres-X Secrets from all the environments.


This pattern of changes ensures there is no broken deployment.